### PR TITLE
feat: adds capacity option for circular buffers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ declare class Denque<T = any> {
 }
 
 interface IDenqueOptions {
-  capacity: number
+  capacity?: number
 }
 
 export = Denque;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 declare class Denque<T = any> {
   constructor();
   constructor(array: T[]);
+  constructor(array: T[], options: IDenqueOptions);
 
   push(item: T): number;
   unshift(item: T): number;
@@ -21,6 +22,10 @@ declare class Denque<T = any> {
   toArray(): T[];
 
   length: number;
+}
+
+interface IDenqueOptions {
+  capacity: number
 }
 
 export = Denque;

--- a/index.js
+++ b/index.js
@@ -136,15 +136,12 @@ Denque.prototype.push = function push(item) {
   var tail = this._tail;
   this._list[tail] = item;
   this._tail = (tail + 1) & this._capacityMask;
-
   if (this._tail === this._head) {
     this._growArray();
   }
-
   if (this.size() > this._capacity) {
     this.shift();
   }
-
   if (this._head < this._tail) return this._tail - this._head;
   else return this._capacityMask + 1 - (this._head - this._tail);
 };

--- a/index.js
+++ b/index.js
@@ -3,9 +3,12 @@
 /**
  * Custom implementation of a double ended queue.
  */
-function Denque(array) {
+function Denque(array, options) {
+  var options = options || { capacity: Infinity };
+
   this._head = 0;
   this._tail = 0;
+  this._capacity = options.capacity;
   this._capacityMask = 0x3;
   this._list = new Array(4);
   if (Array.isArray(array)) {
@@ -104,6 +107,7 @@ Denque.prototype.unshift = function unshift(item) {
   this._head = (this._head - 1 + len) & this._capacityMask;
   this._list[this._head] = item;
   if (this._tail === this._head) this._growArray();
+  if (this.size() > this._capacity) this.pop();
   if (this._head < this._tail) return this._tail - this._head;
   else return this._capacityMask + 1 - (this._head - this._tail);
 };
@@ -132,8 +136,13 @@ Denque.prototype.push = function push(item) {
   var tail = this._tail;
   this._list[tail] = item;
   this._tail = (tail + 1) & this._capacityMask;
+
   if (this._tail === this._head) {
     this._growArray();
+  }
+
+  if (this.size() > this._capacity) {
+    this.shift();
   }
 
   if (this._head < this._tail) return this._tail - this._head;

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
  * Custom implementation of a double ended queue.
  */
 function Denque(array, options) {
-  var options = options || { capacity: Infinity };
+  var options = options || {};
 
   this._head = 0;
   this._tail = 0;
@@ -107,7 +107,7 @@ Denque.prototype.unshift = function unshift(item) {
   this._head = (this._head - 1 + len) & this._capacityMask;
   this._list[this._head] = item;
   if (this._tail === this._head) this._growArray();
-  if (this.size() > this._capacity) this.pop();
+  if (this._capacity && this.size() > this._capacity) this.pop();
   if (this._head < this._tail) return this._tail - this._head;
   else return this._capacityMask + 1 - (this._head - this._tail);
 };
@@ -139,7 +139,7 @@ Denque.prototype.push = function push(item) {
   if (this._tail === this._head) {
     this._growArray();
   }
-  if (this.size() > this._capacity) {
+  if (this._capacity && this.size() > this._capacity) {
     this.shift();
   }
   if (this._head < this._tail) return this._tail - this._head;

--- a/test/denque.js
+++ b/test/denque.js
@@ -140,6 +140,16 @@ describe('Denque.prototype.push', function () {
     assert.deepEqual(a.toArray(), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 1]);
   });
 
+  it('should respect capacity', function () {
+    var a = new Denque([1, 2, 3], { capacity: 3 });
+    a.push(4);
+
+    assert.equal(a.size(), 3);
+    assert.equal(a.peekAt(0), 2);
+    assert.equal(a.peekAt(1), 3);
+    assert.equal(a.peekAt(2), 4);
+  });
+
 });
 
 describe('Denque.prototype.unshift', function () {
@@ -201,6 +211,16 @@ describe('Denque.prototype.unshift', function () {
     assert(a.length === ret);
     assert(ret === 17);
     assert.deepEqual(a.toArray(), [1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+  });
+
+  it('should respect capacity', function () {
+    var a = new Denque([1, 2, 3], { capacity: 3 });
+    a.unshift(0);
+
+    assert.equal(a.size(), 3);
+    assert.equal(a.peekAt(0), 0);
+    assert.equal(a.peekAt(1), 1);
+    assert.equal(a.peekAt(2), 2);
   });
 
 });

--- a/test/type/index.ts
+++ b/test/type/index.ts
@@ -3,6 +3,7 @@ import Denque = require("../../");
 
 const queue = new Denque(["my", "super", "array"]);
 new Denque(); // also work
+new Denque<number>([1, 2, 3], { capacity: 3 });
 
 queue.push("awesome");
 queue.unshift("typescript");


### PR DESCRIPTION
This PR adds the ability to pass an optional configuration object to the Denque constructor to allow a max capacity to be specified, essentially allowing it to operate as a circular buffer.

fixes #24 