### PR TITLE
fix!: `push` & `unshift` should accept `undefined` values to match behaviour of `Array` 

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ Denque.prototype.size = function size() {
  * @param item
  */
 Denque.prototype.unshift = function unshift(item) {
-  if (item === undefined) return this.size();
+  if (arguments.length === 0) return this.size();
   var len = this._list.length;
   this._head = (this._head - 1 + len) & this._capacityMask;
   this._list[this._head] = item;
@@ -132,7 +132,7 @@ Denque.prototype.shift = function shift() {
  * @param item
  */
 Denque.prototype.push = function push(item) {
-  if (item === undefined) return this.size();
+  if (arguments.length === 0) return this.size();
   var tail = this._tail;
   this._list[tail] = item;
   this._tail = (tail + 1) & this._capacityMask;

--- a/test/denque.js
+++ b/test/denque.js
@@ -90,6 +90,13 @@ describe('Denque.prototype.push', function () {
     assert(ret === 0);
   });
 
+
+  it('Should accept undefined values', function () {
+    var a = new Denque();
+    a.push(undefined);
+    assert(a.length === 1);
+  });
+
   it('Should add falsey elements (except undefined)', function () {
     var a = new Denque();
     // var before = a.length;
@@ -161,6 +168,12 @@ describe('Denque.prototype.unshift', function () {
     assert(ret === before);
     assert(a.length === ret);
     assert(ret === 0);
+  });
+
+  it('Should accept undefined values', function () {
+    var a = new Denque();
+    a.unshift(undefined);
+    assert(a.length === 1);
   });
 
   it('Should unshift falsey elements (except undefined)', function () {


### PR DESCRIPTION
Fixes #25 