### PR TITLE
Optimized growth and array copy

### DIFF
--- a/index.js
+++ b/index.js
@@ -400,17 +400,18 @@ Denque.prototype._fromArray = function _fromArray(array) {
  * @private
  */
 Denque.prototype._copyArray = function _copyArray(fullCopy, size) {
-  const src = this._list;
-  const len = src.length;
+  var src = this._list;
+  var len = src.length;
   
-  let dest = new Array(size | this.length);
+  var dest = new Array(size | this.length);
 
-  let k = 0;
+  var k = 0;
+  var i;
   if (fullCopy || this._head > this._tail) {
-    for (let i = this._head; i < len; i++) dest[k++] = src[i];
-    for (let i = 0; i < this._tail; i++) dest[k++] = src[i];
+    for (i = this._head; i < len; i++) dest[k++] = src[i];
+    for (i = 0; i < this._tail; i++) dest[k++] = src[i];
   } else {
-    for (let i = this._head; i < this._tail; i++) dest[k++] = src[i];
+    for (i = this._head; i < this._tail; i++) dest[k++] = src[i];
   }
 
   return dest;
@@ -423,7 +424,7 @@ Denque.prototype._copyArray = function _copyArray(fullCopy, size) {
 Denque.prototype._growArray = function _growArray() {
   if (this._head != 0) {
     // double array size and copy existing data, head to end, then beginning to tail.
-    const newList = this._copyArray(true, this._list.length << 1);
+    var newList = this._copyArray(true, this._list.length << 1);
 
     this._tail = this._list.length;
     this._head = 0;

--- a/index.js
+++ b/index.js
@@ -395,38 +395,45 @@ Denque.prototype._fromArray = function _fromArray(array) {
 /**
  *
  * @param fullCopy
+ * @param size Initialize the array with a specific size. Will default to the current list size
  * @returns {Array}
  * @private
  */
-Denque.prototype._copyArray = function _copyArray(fullCopy) {
-  var newArray = [];
-  var list = this._list;
-  var len = list.length;
-  var i;
+Denque.prototype._copyArray = function _copyArray(fullCopy, size) {
+  const src = this._list;
+  const len = src.length;
+  
+  let dest = new Array(size | this.length);
+
+  let k = 0;
   if (fullCopy || this._head > this._tail) {
-    for (i = this._head; i < len; i++) newArray.push(list[i]);
-    for (i = 0; i < this._tail; i++) newArray.push(list[i]);
+    for (let i = this._head; i < len; i++) dest[k++] = src[i];
+    for (let i = 0; i < this._tail; i++) dest[k++] = src[i];
   } else {
-    for (i = this._head; i < this._tail; i++) newArray.push(list[i]);
+    for (let i = this._head; i < this._tail; i++) dest[k++] = src[i];
   }
-  return newArray;
-};
+
+  return dest;
+}
 
 /**
  * Grows the internal list array.
  * @private
  */
 Denque.prototype._growArray = function _growArray() {
-  if (this._head) {
-    // copy existing data, head to end, then beginning to tail.
-    this._list = this._copyArray(true);
+  if (this._head != 0) {
+    // double array size and copy existing data, head to end, then beginning to tail.
+    const newList = this._copyArray(true, this._list.length << 1);
+
+    this._tail = this._list.length;
     this._head = 0;
+
+    this._list = newList;
+  } else {
+    this._tail = this._list.length;
+    this._list.length <<= 1;
   }
 
-  // head is at 0 and array is now full, safe to extend
-  this._tail = this._list.length;
-
-  this._list.length <<= 1;
   this._capacityMask = (this._capacityMask << 1) | 1;
 };
 


### PR DESCRIPTION
I changed the `_copyArray` and `_growArray` functions to use an array with predefined size (`new Array(N)`) to avoid implicit copies & reallocations. Despite some sources saying that preallocation using `new Array(N)` does not improve performance, all my tests and benchmarks suggest otherwise. All tests are of course still working. I made a [comprehensive benchmark setup](https://github.com/dnlmlr/denque-benches) that contains the orginal benchmarks and a few extra, comparing the original and modified implementations.

Some of the benchmarks with large numbers of operations / sec and similar performance between original and modified were really inconsistent and traded places when running in a different order. So I would not count those as regressions.

However the `splice` benchmark showed consistently better performance and the newly added `growth` and `toArray` benchmarks had major performance improvements compared to the original. 

The `growth` benchmark tests the actual performance while growing and shifting at the same time (1000x push, 500x shift, 1000x push, 1500x shift).

The `toArray` benchmark simply measures the time it takes to run `toArray` (which also uses the `_copyArray` function directly).

> Running growth.js
> denque x 27,636 ops/sec ±1.73% (82 runs sampled)
> denque (mod) x 50,995 ops/sec ±0.30% (93 runs sampled)
> double-ended-queue x 21,171 ops/sec ±0.16% (95 runs sampled)
> 
> Running splice.js
> denque.splice x 827,636 ops/sec ±20.30% (77 runs sampled)
> denque.splice (mod) x 955,175 ops/sec ±7.15% (84 runs sampled)
> native array splice x 10,934 ops/sec ±36.89% (28 runs sampled)
> 
> Running toArray.js
> denque x 22.74 ops/sec ±2.37% (41 runs sampled)
> denque (mod) x 106 ops/sec ±0.42% (76 runs sampled)
> double-ended-queue x 99.84 ops/sec ±0.48% (73 runs sampled)

For the full benchmark results and how to run it please refer to [the repository](https://github.com/dnlmlr/denque-benches).

I normally work with lower level languages so it is entirely possible that my testing is flawed or I missed anything else. Therefore I invite everyone to validate or challenge my results.