### PR TITLE
Additional benchmarks

### DIFF
--- a/benchmark/fromArray.js
+++ b/benchmark/fromArray.js
@@ -1,0 +1,29 @@
+'use strict';
+
+require('./print');
+
+var Benchmark = require('benchmark');
+var suite = new Benchmark.Suite();
+
+var Denque = require('./../');
+var DoubleEndedQueue = require('double-ended-queue');
+
+var l = 100000;
+
+var baseArray = new Array(l);
+
+while (--l) {
+  baseArray.push(l);
+}
+
+suite
+  .add('denque', function () {
+    var queue = new Denque(baseArray);
+  })
+  .add('double-ended-queue', function () {
+    var queue = new DoubleEndedQueue(baseArray);
+  })
+  .on('cycle', function (e) {
+    console.log('' + e.target);
+  })
+  .run();

--- a/benchmark/growth.js
+++ b/benchmark/growth.js
@@ -1,0 +1,33 @@
+'use strict';
+
+require('./print');
+
+var Benchmark = require('benchmark');
+var suite = new Benchmark.Suite();
+
+var Denque = require('./../');
+var DoubleEndedQueue = require('double-ended-queue');
+
+var n = 1000;
+
+suite
+  .add('denque', function () {
+    var denque = new Denque();
+
+    for (var i = 0; i < n; i++) denque.push(i);
+    for (var i = 0; i < n / 2; i++) denque.shift();
+    for (var i = 0; i < n; i++) denque.push(i);
+    for (var i = 0; i < n + n / 2; i++) denque.shift();
+  })
+  .add('double-ended-queue', function () {
+    var doubleEndedQueue = new DoubleEndedQueue();
+
+    for (var i = 0; i < n; i++) doubleEndedQueue.push(i);
+    for (var i = 0; i < n / 2; i++) doubleEndedQueue.shift();
+    for (var i = 0; i < n; i++) doubleEndedQueue.push(i);
+    for (var i = 0; i < n + n / 2; i++) doubleEndedQueue.shift();
+  })
+  .on('cycle', function (e) {
+    console.log('' + e.target);
+  })
+  .run();

--- a/benchmark/toArray.js
+++ b/benchmark/toArray.js
@@ -1,4 +1,5 @@
 'use strict';
+
 require('./print');
 
 var Benchmark = require('benchmark');

--- a/benchmark/toArray.js
+++ b/benchmark/toArray.js
@@ -1,0 +1,109 @@
+'use strict';
+require('./print');
+
+var Benchmark = require('benchmark');
+var suite = new Benchmark.Suite();
+
+var Denque = require('./../');
+var DoubleEndedQueue = require('double-ended-queue');
+
+var denque = new Denque();
+var denque_NonContiguous = new Denque();
+var denque_NonZeroHead = new Denque();
+
+var doubleEndedQueue = new DoubleEndedQueue();
+var doubleEndedQueue_NonContiguous = new DoubleEndedQueue();
+var doubleEndedQueue_NonZeroHead = new DoubleEndedQueue();
+
+var array = new Array();
+
+
+// Number of elements has to be 1 less than a power of 2 in order to ensure that the buffer 
+// wrapping occurs on the _NonContiguous variant and not the base variant
+var l = (1 << 21) - 1;
+var l_half = (l / 2) >> 0;
+
+
+for (var i = 0; i < l; i++) {
+  denque.push(i);
+  denque_NonContiguous.push(i);
+  denque_NonZeroHead.push(i);
+
+  doubleEndedQueue.push(i);
+  doubleEndedQueue_NonContiguous.push(i);
+  doubleEndedQueue_NonZeroHead.push(i);
+
+  array.push(i)
+}
+
+for (var i = 0; i < l_half; i++) {
+  denque_NonZeroHead.push(i);
+  doubleEndedQueue_NonZeroHead.push(i);
+}
+
+// Shift half and push half. This should make the internal buffer non contiguous and about half 
+// before and half after the wrap
+for (var i = 0; i < l_half; i++) {
+  denque_NonContiguous.shift();
+  denque_NonContiguous.push(i);
+
+  doubleEndedQueue_NonContiguous.shift();
+  doubleEndedQueue_NonContiguous.push(i);
+
+  denque_NonZeroHead.shift();
+  doubleEndedQueue_NonZeroHead.shift();
+}
+
+// Make sure that the denqueue buffer is contiguous or not
+console.assert(denque._head < denque._tail, "Denque (contiguous) buffer is not contiguous");
+console.assert(
+  denque_NonZeroHead._head < denque_NonZeroHead._tail,
+  "Denque (non zero head) buffer is not contiguous"
+);
+console.assert(
+  denque_NonContiguous._head > denque_NonContiguous._tail,
+  "Denque (non-contiguous) buffer is contiguous"
+);
+
+// Make sure that the same number of elements is used in each queue, despite shifts
+console.assert(denque.length == denque_NonContiguous.length, "Denque variant length missmatch");
+console.assert(denque.length == denque_NonZeroHead.length, "Denque variant length missmatch");
+console.assert(denque.length == doubleEndedQueue.length, "Denque vs double-ended-queue length missmatch");
+console.assert(doubleEndedQueue.length == doubleEndedQueue_NonContiguous.length, "Denque variant length missmatch");
+console.assert(doubleEndedQueue.length == doubleEndedQueue_NonZeroHead.length, "Denque variant length missmatch");
+
+
+suite
+  .add('denque (head at 0)', function () {
+    var arr = denque.toArray();
+  })
+  .add('double-ended-queue (head at 0)', function () {
+    var arr = doubleEndedQueue.toArray();
+  })
+  .add('denque (non-contiguous)', function () {
+    var arr = denque_NonContiguous.toArray();
+  })
+  .add('double-ended-queue (non-contiguous)', function () {
+    var arr = doubleEndedQueue_NonContiguous.toArray();
+  })
+  .add('denque (non zero head)', function () {
+    var arr = denque_NonZeroHead.toArray();
+  })
+  .add('double-ended-queue (non zero head)', function () {
+    var arr = doubleEndedQueue_NonZeroHead.toArray();
+  })
+  .add('array copy (prealloc + for loop)', function () {
+    var arr = new Array(array.length);
+    for (var i = 0; i < array.length; i++) arr[i] = array[i];
+  })
+  .add('array copy (no prealloc + for loop)', function () {
+    var arr = new Array();
+    for (var i = 0; i < array.length; i++) arr.push(array[i]);
+  })
+  .add('array copy (slice)', function () {
+    var arr = array.slice(0, array.length);
+  })
+  .on('cycle', function (e) {
+    console.log('' + e.target);
+  })
+  .run();

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "benchmark_remove": "node benchmark/remove",
     "benchmark_removeOne": "node benchmark/removeOne",
     "benchmark_growth": "node benchmark/growth",
-    "benchmark_toArray": "node benchmark/toArray"
+    "benchmark_toArray": "node benchmark/toArray",
+    "benchmark_fromArray": "node benchmark/fromArray"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "benchmark_2mil": "node benchmark/two_million",
     "benchmark_splice": "node benchmark/splice",
     "benchmark_remove": "node benchmark/remove",
-    "benchmark_removeOne": "node benchmark/removeOne"
+    "benchmark_removeOne": "node benchmark/removeOne",
+    "benchmark_growth": "node benchmark/growth"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "benchmark_splice": "node benchmark/splice",
     "benchmark_remove": "node benchmark/remove",
     "benchmark_removeOne": "node benchmark/removeOne",
-    "benchmark_growth": "node benchmark/growth"
+    "benchmark_growth": "node benchmark/growth",
+    "benchmark_toArray": "node benchmark/toArray"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
As suggested in #43 I added the `growth` benchmark. 

I also added two other benchmarks that are related to more performance improvments.

The first is an enhanced version of the `toArray` benchmark. That benchmark does what the name suggests and benchmarks the performance of the `toArray` function. It also does this for 3 scenarios: When the internal buffer is contiguous, once with the head at index 0 and once with the head not at 0. The last scenario is when the buffer is wrapped (head > tail). On top of that I added an "array to array copy" as a baseline comparison.

The second additional benchmark is the `fromArray` benchmark which simply creates a `Denque` from a given array.

I'll make a PR with further improvements to the `_fromArray` and `_copyArray` functions which in turn improve the performance in the two additional benchmarks significantly.