### PR TITLE
Optimizations for toArray and fromArray

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,14 +5,16 @@
  */
 function Denque(array, options) {
   var options = options || {};
+  this._capacity = options.capacity;
 
   this._head = 0;
   this._tail = 0;
-  this._capacity = options.capacity;
-  this._capacityMask = 0x3;
-  this._list = new Array(4);
+
   if (Array.isArray(array)) {
     this._fromArray(array);
+  } else {
+    this._capacityMask = 0x3;
+    this._list = new Array(4);
   }
 }
 
@@ -389,7 +391,14 @@ Denque.prototype.toArray = function toArray() {
  * @private
  */
 Denque.prototype._fromArray = function _fromArray(array) {
-  for (var i = 0; i < array.length; i++) this.push(array[i]);
+  var length = array.length;
+  var capacity = this._nextPowerOf2(length);
+
+  this._list = new Array(capacity);
+  this._capacityMask = capacity - 1;
+  this._tail = length;
+
+  for (var i = 0; i < length; i++) this._list[i] = array[i];
 };
 
 /**
@@ -455,5 +464,17 @@ Denque.prototype._shrinkArray = function _shrinkArray() {
   this._capacityMask >>>= 1;
 };
 
+/**
+ * Find the next power of 2, at least 4
+ * @private
+ * @param {number} num 
+ * @returns {number}
+ */
+Denque.prototype._nextPowerOf2 = function _nextPowerOf2(num) {
+  var log2 = Math.log(num) / Math.log(2);
+  var nextPow2 = 1 << (log2 + 1);
+
+  return Math.max(nextPow2, 4);
+}
 
 module.exports = Denque;

--- a/index.js
+++ b/index.js
@@ -401,14 +401,22 @@ Denque.prototype._fromArray = function _fromArray(array) {
  */
 Denque.prototype._copyArray = function _copyArray(fullCopy, size) {
   var src = this._list;
-  var len = src.length;
-  
-  var dest = new Array(size | this.length);
+  var capacity = src.length;
+  var length = this.length;
+  size = size | length;
+
+  // No prealloc requested and the buffer is contiguous
+  if (size == length && this._head < this._tail) {
+    // Simply do a fast slice copy
+    return this._list.slice(this._head, this._tail);
+  }
+
+  var dest = new Array(size);
 
   var k = 0;
   var i;
   if (fullCopy || this._head > this._tail) {
-    for (i = this._head; i < len; i++) dest[k++] = src[i];
+    for (i = this._head; i < capacity; i++) dest[k++] = src[i];
     for (i = 0; i < this._tail; i++) dest[k++] = src[i];
   } else {
     for (i = this._head; i < this._tail; i++) dest[k++] = src[i];


### PR DESCRIPTION
I made some further optimizations to the `_copyArray` function that I missed last time (#43) and also optimized the `_fromArray` function. This in turn provides a large improvement when initializing the `Denque` from an array and also in some situations when exporting to an array.

Creating the queue from an array with the new preallocating code avoids growth and is a significant improvement on large arrays: 
- `338 ops/sec vs 841 ops/sec`
```
Running fromArray.js
denque x 338 ops/sec ±0.88% (84 runs sampled)
denque (mod) x 841 ops/sec ±1.01% (85 runs sampled)
double-ended-queue x 176 ops/sec ±0.90% (81 runs sampled)
```

Using `Array.slice` in `_copyArray` to create copies with the same size on contiguous buffer data is also a pretty good performance boost in situations where it applies. This applies in every situation where `head < tail`. Not sure why but before when `head < tail` and `head != 0`, is was noticeably slow. This is now fixed
- `92.41 ops/sec vs 156 ops/sec` when head is 0, but no wrapping
- `39.84 ops/sec vs 151 ops/sec ` when head is not 0, but no wrapping
- `90.74 ops/sec vs 91.14 ops/sec` when wrapping
```
Running toArray.js
denque (head at 0) x 92.41 ops/sec ±0.97% (68 runs sampled)
denque (mod) (head at 0) x 156 ops/sec ±1.33% (72 runs sampled)
double-ended-queue (head at 0) x 87.69 ops/sec ±1.05% (74 runs sampled)
denque (non-contiguous) x 90.74 ops/sec ±0.89% (66 runs sampled)
denque (mod) (non-contiguous) x 91.14 ops/sec ±0.91% (67 runs sampled)
double-ended-queue (non-contiguous) x 88.43 ops/sec ±0.69% (75 runs sampled)
denque (non zero head) x 39.84 ops/sec ±0.71% (53 runs sampled)
denque (mod) (non zero head) x 151 ops/sec ±0.94% (70 runs sampled)
double-ended-queue (non zero head) x 87.74 ops/sec ±0.73% (74 runs sampled)
array copy (prealloc + for loop) x 94.32 ops/sec ±0.67% (71 runs sampled)
array copy (no prealloc + for loop) x 27.99 ops/sec ±5.86% (48 runs sampled)
array copy (slice) x 157 ops/sec ±0.43% (79 runs sampled)
```

The full benchmark results and scripts for validation is again found [in the benchmark repository](https://github.com/dnlmlr/denque-benches/tree/7c01ab0541f51fae99bd4312c1de05f80a229d5f)

PS: The `_fromArray` optimization adds a `_nextPowerOf2` function that calculates the next power of 2 to directly allocate the buffer with the correct size. This could be used to implement #42. 