### PR TITLE
fix: issue where `clear()` is still keeping references to the elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -358,6 +358,7 @@ Denque.prototype.splice = function splice(index, count) {
  * Soft clear - does not reset capacity.
  */
 Denque.prototype.clear = function clear() {
+  this._list = new Array(this._list.length);
   this._head = 0;
   this._tail = 0;
 };


### PR DESCRIPTION
- Clear didn't delete the actual elements from the _list buffer. This
  caused something like a memory leak, described in  #44
- Fixed this issue by simply overwriting the _list with a new array of
  the same size
- This keeps the capacity the same but allows the GC to free the memory