### PR TITLE
fix: removeOne(-1) from the end

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ Denque.prototype.removeOne = function removeOne(index) {
   i = (this._head + i) & this._capacityMask;
   var item = this._list[i];
   var k;
-  if (index < size / 2) {
+  if (i < size / 2) {
     for (k = index; k > 0; k--) {
       this._list[i] = this._list[i = (i - 1 + len) & this._capacityMask];
     }

--- a/test/denque.js
+++ b/test/denque.js
@@ -446,6 +446,12 @@ describe('Denque.prototype.removeOne', function () {
     assert(a.length === 0);
   });
 
+  it('Should work with negative indexing', function () {
+    var a = new Denque([1, 2, 3, 4, 5, 6, 7, 8]);
+    assert(a.removeOne(-1) === 8);
+    assert(a.length === 7);
+    assert.deepEqual(a.toArray(), [1, 2, 3, 4, 5, 6, 7]);
+  });
 });
 
 describe('Denque.prototype.remove', function () {


### PR DESCRIPTION
## mcve
```js
const b = new Denque([1, 2, 3, 4, 5, 6, 7, 8]);
console.log(b.removeOne(-1));
console.log(b.toArray());
```

## expected result
```js
8
[1, 2, 3, 4, 5, 6, 7]
```

## actual result
```js
8
[2, 3, 4, 5, 6, 7, undefined]
```